### PR TITLE
Add council data to all registrations

### DIFF
--- a/src/connectors/registrationDb/registrationDb.connector.js
+++ b/src/connectors/registrationDb/registrationDb.connector.js
@@ -226,13 +226,18 @@ const getSingleRegistration = async (fsa_rn, council) => {
 };
 
 const getFullRegistration = async (registration, fields = []) => {
-  const { id, fsa_rn } = registration;
+  const { id, fsa_rn } = registration.dataValues;
   const {
     competent_authority_id,
     local_council_full_name,
     local_council_url
   } = await getCouncilByRegCouncil(registration.dataValues.council);
-  const { collected, collected_at, createdAt, updatedAt } = registration;
+  const {
+    collected,
+    collected_at,
+    createdAt,
+    updatedAt
+  } = registration.dataValues;
   const establishment = fields.includes("establishment")
     ? await getFullEstablishment(registration.id)
     : {};

--- a/src/connectors/registrationDb/registrationDb.connector.js
+++ b/src/connectors/registrationDb/registrationDb.connector.js
@@ -226,22 +226,33 @@ const getSingleRegistration = async (fsa_rn, council) => {
 };
 
 const getFullRegistration = async (registration, fields = []) => {
+  const { id, fsa_rn } = registration;
+  const {
+    competent_authority_id,
+    local_council_full_name,
+    local_council_url
+  } = await getCouncilByRegCouncil(registration.dataValues.council);
+  const { collected, collected_at, createdAt, updatedAt } = registration;
   const establishment = fields.includes("establishment")
     ? await getFullEstablishment(registration.id)
     : {};
   const metadata = fields.includes("metadata")
     ? await getFullMetadata(registration.id)
     : {};
-  const council = await getCouncilByRegCouncil(registration.dataValues.council);
 
+  // Assign values in consistent order
   const newRegistration = Object.assign(
-    registration.dataValues,
+    { id, fsa_rn },
+    {
+      council: local_council_full_name,
+      competent_authority_id,
+      local_council_url
+    },
+    { collected, collected_at, createdAt, updatedAt },
     { establishment },
     { metadata }
   );
-  newRegistration.competent_authority_id = council.competent_authority_id;
-  newRegistration.local_council_url = council.local_council_url;
-  newRegistration.council = council.local_council_full_name;
+
   return newRegistration;
 };
 

--- a/src/connectors/registrationDb/registrationDb.connector.test.js
+++ b/src/connectors/registrationDb/registrationDb.connector.test.js
@@ -152,6 +152,11 @@ describe("collect.service", () => {
           { id: 1, dataValues: { fsa_rn: "1234" } },
           { id: 2, dataValues: { fsa_rn: "5678" } }
         ]);
+        Council.findOne.mockImplementation(() => ({
+          local_council_full_name: "Area Council",
+          competent_authority_id: "5678",
+          local_council_url: "area"
+        }));
         Activities.findOne.mockImplementation(() => {
           throw new Error("Failed");
         });

--- a/src/connectors/registrationDb/registrationDb.connector.test.js
+++ b/src/connectors/registrationDb/registrationDb.connector.test.js
@@ -176,10 +176,18 @@ describe("collect.service", () => {
           { id: 1, dataValues: { fsa_rn: "1234" } },
           { id: 2, dataValues: { fsa_rn: "5678" } }
         ]);
+        Council.findOne.mockImplementation(() => ({
+          local_council_full_name: "Area Council",
+          competent_authority_id: "5678",
+          local_council_url: "area"
+        }));
         result = await getAllRegistrationsByCouncil("cardiff", true, []);
       });
       it("should return just the registration fields", () => {
         expect(result[0].fsa_rn).toBe("1234");
+        expect(result[0].competent_authority_id).toBe("5678");
+        expect(result[0].local_council_url).toBe("area");
+        expect(result[0].council).toBe("Area Council");
         expect(result[0].establishment).toEqual({});
         expect(result[0].metadata).toEqual({});
       });


### PR DESCRIPTION
The council data needs to be returned on every route so I updated accordingly and made processing a bit simpler. 