### PR TITLE
Ensure script waits for truncate to complete

### DIFF
--- a/tests/postgres-seed/postgres-clear.js
+++ b/tests/postgres-seed/postgres-clear.js
@@ -18,5 +18,6 @@ const clearTables = async () => {
 };
 
 logEmitter.emit(INFO, `Clearing tables`);
-clearTables()
-  .then((clearResult) => console.log(`Tables cleared: ${clearResult}`));;
+clearTables().then((clearResult) =>
+  console.log(`Tables cleared: ${clearResult}`)
+);

--- a/tests/postgres-seed/postgres-clear.js
+++ b/tests/postgres-seed/postgres-clear.js
@@ -14,7 +14,9 @@ const clearTables = async () => {
   await connectToDb();
   await Registration.truncate({ cascade: true });
   closeConnection();
+  return true;
 };
 
 logEmitter.emit(INFO, `Clearing tables`);
-clearTables();
+clearTables()
+  .then((clearResult) => console.log(`Tables cleared: ${clearResult}`));;


### PR DESCRIPTION
Reset DB script before component tests in release pipeline intermittently fails to work correctly due to script not waiting for async truncate to complete before continuing onto the seed script.